### PR TITLE
Fix type annotation to use typing module for compatibility

### DIFF
--- a/globber.py
+++ b/globber.py
@@ -15,6 +15,7 @@
 # This file has been altered from its original form.
 
 import re
+from typing import List
 
 _double_star_after_invalid_regex = re.compile(r'[^/\\]\*\*')
 _double_star_first_before_invalid_regex = re.compile('^\\*\\*[^/]')
@@ -42,7 +43,7 @@ def _match_component(pattern_component: str, file_name_component: str) -> bool:
         return _match_component(pattern_component[1:], file_name_component[1:])
 
 
-def _match_components(pattern_components: list[str], file_name_components: list[str]) -> bool:
+def _match_components(pattern_components: List[str], file_name_components: List[str]) -> bool:
     if len(pattern_components) == 0 and len(file_name_components) == 0:
         return True
     if len(pattern_components) == 0:
@@ -83,5 +84,5 @@ def match(pattern: str, file_name: str) -> bool:
         pattern = pattern.replace('**/**', '**')
     pattern_components = pattern.split('/')
     # We split on '\' as well as '/' to support unix and windows-style paths
-    file_name_components: list[str] = re.split(r'[\\/]', file_name)
+    file_name_components: List[str] = re.split(r'[\\/]', file_name)
     return _match_components(pattern_components, file_name_components)


### PR DESCRIPTION
Hi 👋 . This PR intends to fix a "Python's Typing" related error, which I faced on applying `advanced-security/filter-sarif@v1`.

## Problem

The workflow fails with `TypeError: 'type' object is not subscriptable` error when `filter-sarif@v1` is applied (applying `filter-sarif@main` doesn't cause this error).

```
Run advanced-security/filter-sarif@v1
Run unset LD_PRELOAD
Traceback (most recent call last):
  File "/home/runner/work/_actions/advanced-security/filter-sarif/v1/filter_sarif.py", line 14, in <module>
    from globber import match
  File "/home/runner/work/_actions/advanced-security/filter-sarif/v1/globber.py", line 45, in <module>
    def _match_components(pattern_components: list[str], file_name_components: list[str]) -> bool:
TypeError: 'type' object is not subscriptable
Error: Process completed with exit code 1.
```
<img width="1115" alt="error_01" src="https://user-images.githubusercontent.com/1172471/205443253-5260bf0c-047b-4cc2-a82d-17489b2a8eea.png">

## Reason

- [Type Hinting Generics In Standard Collections](https://peps.python.org/pep-0585/) is supported on Python `3.9`, but the default python version for `ubuntu-latest` (or `ubuntu-22.04`) is `3.8`, which seems causing this error.
- This error doesn't occur if the newer version of python is explicitly installed with `actions/setup-python`, but it requires additional step in the workflow (not ideal).

**example Results with `runs-on: ubuntu-latest`**
<img width="564" alt="image" src="https://user-images.githubusercontent.com/1172471/205446046-40c8cc30-d6a5-4699-a7b9-04f8b7e8c72d.png">

## Proposed Change

Apply `from typing import List` as similar way as some lines in [filter_sarif.py](https://github.com/advanced-security/filter-sarif/blob/develop/filter_sarif.py#L12).
