### PR TITLE
Using `$GITHUB_ACTION_PATH` env var instead of `${{ github.action_path }}` context

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ runs:
     - name: filter
       run: |
         unset LD_PRELOAD
-        python3 "${{ github.action_path }}/filter_sarif.py" --input "${{ inputs.input }}" --output "${{ inputs.output }}" --split-lines -- "${{ inputs.patterns }}"
+        python3 "$GITHUB_ACTION_PATH/filter_sarif.py" --input "${{ inputs.input }}" --output "${{ inputs.output }}" --split-lines -- "${{ inputs.patterns }}"
       shell: bash


### PR DESCRIPTION
When running in a container, `${{ github.action_path }}` resolves to the wrong location:

```
python3: can't open file '/home/runner/work/_actions/advanced-security/filter-sarif/v1/filter_sarif.py': [Errno 2] No such file or directory
```

Using the environmental variable works.

According to https://github.com/actions/runner/issues/716, this change should not be needed. But it is! 🤷 