### PR TITLE
Specify category in upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ jobs:
       uses: github/codeql-action/upload-sarif@v2
       with:
         sarif_file: sarif-results/java.sarif
+        category: "/language:${{matrix.language}}"
 
     - name: Upload loc as a Build Artifact
       uses: actions/upload-artifact@v2.2.0


### PR DESCRIPTION
Most users are migrating from the [ CodeQL starter workflow which specifies a category](https://github.com/actions/starter-workflows/blob/1c61cfc44d2a372d82735888ab06bc9491e1e3d6/code-scanning/codeql.yml#L82) on SARIF upload (via analysis step). If they copy paste the sample code here they will have duplicate set of alerts, and will not close out any filtered out findings as this sample did not include the same category on sarif upload.


