### PR TITLE
Update recommended usage to preserve diagnostics for failed runs

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:
-        upload: False
+        upload: failure-only
         output: sarif-results
 
     - name: filter-sarif

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
@@ -38,7 +38,7 @@ jobs:
         javatest/build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         upload: False
         output: sarif-results
@@ -58,12 +58,12 @@ jobs:
         output: sarif-results/java.sarif
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: sarif-results/java.sarif
 
     - name: Upload loc as a Build Artifact
-      uses: actions/upload-artifact@v2.2.0
+      uses: actions/upload-artifact@v4
       with:
         name: sarif-results
         path: sarif-results

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ jobs:
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
       with:
-        upload: False
+        category: "/language:${{matrix.language}}"
         output: sarif-results
+        upload: failure-only
 
     - name: filter-sarif
       uses: advanced-security/filter-sarif@v1
@@ -53,7 +54,6 @@ jobs:
       uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: sarif-results/java.sarif
-        category: "/language:${{matrix.language}}"
 
     - name: Upload loc as a Build Artifact
       uses: actions/upload-artifact@v4
@@ -63,7 +63,7 @@ jobs:
         retention-days: 1
 ```
 
-Note how we provided `upload: False` and `output: sarif-results` to the `analyze` action. That way we can filter the SARIF with the `filter-sarif` action before uploading it via `upload-sarif`. Finally, we also attach the resulting SARIF file to the build, which is convenient for later inspection.
+Note how we provided `upload: failure-only` and `output: sarif-results` to the `analyze` action. That way we can filter the SARIF with the `filter-sarif` action before uploading it via `upload-sarif`. Diagnostic output is still uploaded and visible on the [tool status page](https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/about-the-tool-status-page) if the run fails. Finally, we also attach the resulting SARIF file to the build, which is convenient for later inspection.
 
 # Patterns
 

--- a/README.md
+++ b/README.md
@@ -24,18 +24,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
       with:
         upload: False
         output: sarif-results
@@ -50,13 +50,13 @@ jobs:
         output: sarif-results/java.sarif
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v3
       with:
         sarif_file: sarif-results/java.sarif
         category: "/language:${{matrix.language}}"
 
     - name: Upload loc as a Build Artifact
-      uses: actions/upload-artifact@v2.2.0
+      uses: actions/upload-artifact@v4
       with:
         name: sarif-results
         path: sarif-results


### PR DESCRIPTION
This PR makes some changes to the recommended usage of this Action:

- Bump the version numbers of referenced Actions to their latest major versions.
- Use `upload: failure-only` instead of `upload: false`.  This means that diagnostic output is still uploaded and visible on the [tool status page](https://docs.github.com/en/code-security/code-scanning/managing-your-code-scanning-configuration/about-the-tool-status-page) if the run fails.  (See https://github.com/github/codeql-action/blob/7bde9061b48b68e993ca909411613cf15bd12708/analyze/action.yml#L15)
- Move the `category` input to the `analyze` Action so that we can inject this with CodeQL rather than needing to post-process the SARIF in the `upload-sarif` Action.