### PR TITLE
Update filter_sarif.py: use UTF-8 as encoding for reading/writing SARIF content

### DIFF
--- a/filter_sarif.py
+++ b/filter_sarif.py
@@ -79,7 +79,7 @@ def filter_sarif(args):
             )
         )
 
-    with open(args.input, 'r') as f:
+    with open(args.input, 'r', encoding='utf-8') as f:
         s = json.load(f)
 
     for run in s.get('runs', []):
@@ -107,7 +107,7 @@ def filter_sarif(args):
                     new_results.append(r)
             run['results'] = new_results
 
-    with open(args.output, 'w') as f:
+    with open(args.output, 'w', encoding='utf-8') as f:
         json.dump(s, f, indent=2)
 
 


### PR DESCRIPTION
This pull request ensures that SARIF content is read and written using the UTF-8 character encoding. On many systems UTF-8 is the default, however, on systems where this isn't the case the `filter-sarif` script could fail when trying to read SARIF data.