### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,4 +1,6 @@
 name: "Action Test"
+permissions:
+  contents: read
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/action-test.yml
+++ b/.github/workflows/action-test.yml
@@ -1,6 +1,7 @@
 name: "Action Test"
 permissions:
   contents: read
+  security-events: write
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for <a href="https://github.com/advanced-security/filter-sarif/security/code-scanning/7">https://github.com/advanced-security/filter-sarif/security/code-scanning/7</a>

To fix the problem, explicitly define GITHUB_TOKEN permissions at the workflow root. Since this workflow has only one job, adding a root-level `permissions:` block with minimal access is clean and future-proof. For this CodeQL workflow, it needs to read repository contents and upload SARIF results to code security.

Best single fix without changing functionality:
- At the top of `.github/workflows/action-test.yml`, after the `name:` line and before `on:`, add a `permissions:` block with the minimal required permissions.
- This will apply to all jobs in the workflow (currently just `analyze`) and satisfies CodeQL's recommendation.

Concretely:
- Edit `.github/workflows/action-test.yml` around lines 1–3.
- Insert:

```yaml
permissions:
  contents: read
  security-events: write
```

between the existing `name: "Action Test"` and `on:` keys. The `security-events: write` permission is required by `github/codeql-action/upload-sarif` to upload results to GitHub code security. No additional imports or methods are needed; it's pure YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._